### PR TITLE
General error handling refactoring. Change param1 to params

### DIFF
--- a/server/src/Application.cpp
+++ b/server/src/Application.cpp
@@ -49,12 +49,16 @@ void Application::doTask(RequestData data, SendResponseCallback callback)
         } else {
             SPDLOG_WARN("Application::doTask | unknown cmd: {}", data.cmd);
         }
+    } catch (const std::runtime_error &e) {
+        SPDLOG_ERROR("Application::doTask | Error processing cmd: {} | RuntimeException: {}",
+                     data.cmd, e.what());
+        resData.error = std::string("Runtime error: ") + e.what();
     } catch (const std::exception &e) {
         SPDLOG_ERROR("Application::doTask | Error processing cmd: {} | Exception: {}", data.cmd,
                      e.what());
-        // TODO: implement appropriate error handling for the whole system
+        resData.error = std::string("Error: ") + e.what();
     }
-    
+
     callback(resData);
 }
 

--- a/server/src/Application.cpp
+++ b/server/src/Application.cpp
@@ -32,20 +32,29 @@ void Application::doTask(RequestData data, SendResponseCallback callback)
     SPDLOG_TRACE("Application::doTask | cmd - {}", data.cmd);
     ResponseData resData{};
 
-    if (data.cmd == "get_indoor") {
-        resData.measurements = db_.getIndoorCO2Samples();
-    } else if (data.cmd == "get_indoor_after") {
-        resData.measurements = db_.getIndoorCO2SamplesAfterDatetime(data.param1);
-    } else if (data.cmd == "get_outdoor") {
-        resData.measurements = db_.getOutdoorCO2Samples();
-    } else if (data.cmd == "warning_on") {
-        led_.on();
-    } else if (data.cmd == "warning_off") {
-        led_.off();
-    } else {
-        SPDLOG_WARN("Application::doTask | unknown cmd");
+    try {
+        if (data.cmd == "get_indoor") {
+            resData.measurements = db_.getIndoorCO2Samples();
+        } else if (data.cmd == "get_indoor_after") {
+            if (data.params.size() < 1) {
+                throw std::invalid_argument("Missing parameter for 'get_indoor_after'");
+            }
+            resData.measurements = db_.getIndoorCO2SamplesAfterDatetime(data.params.at(0));
+        } else if (data.cmd == "get_outdoor") {
+            resData.measurements = db_.getOutdoorCO2Samples();
+        } else if (data.cmd == "warning_on") {
+            led_.on();
+        } else if (data.cmd == "warning_off") {
+            led_.off();
+        } else {
+            SPDLOG_WARN("Application::doTask | unknown cmd: {}", data.cmd);
+        }
+    } catch (const std::exception &e) {
+        SPDLOG_ERROR("Application::doTask | Error processing cmd: {} | Exception: {}", data.cmd,
+                     e.what());
+        // TODO: implement appropriate error handling for the whole system
     }
-
+    
     callback(resData);
 }
 

--- a/server/src/Data.hpp
+++ b/server/src/Data.hpp
@@ -12,7 +12,7 @@ struct CO2Sample {
 
 struct RequestData {
     std::string cmd{};
-    std::string param1{};
+    std::vector<std::string> params{};
 };
 
 struct ResponseData {

--- a/server/src/Data.hpp
+++ b/server/src/Data.hpp
@@ -17,15 +17,22 @@ struct RequestData {
 
 struct ResponseData {
     std::vector<CO2Sample> measurements{};
+    std::string error{};
 };
 
-// callback for Application layer to send data back to client
+// Callback for Application layer to send data back to client
 using SendResponseCallback = std::function<void(ResponseData)>;
 
-// callback for Network layer to process data from client
+// Callback for Network layer to process data from client
 using DoTaskCallback = std::function<void(RequestData, SendResponseCallback)>;
 
-// callback for fetching outdoor CO2 from OpenWeatherMap
+// Callback for fetching outdoor CO2 from OpenWeatherMap
 using FetchOutdoorCO2TaskCallback = std::function<std::string(const std::string &)>;
 
-#endif
+namespace JsonKeys {
+inline constexpr auto CMD          = "cmd";
+inline constexpr auto PARAMS       = "params";
+inline constexpr auto ERR        = "error";
+} // namespace JsonKeys
+
+#endif // DATA_HPP

--- a/server/src/Devices/CO2Sensor.cpp
+++ b/server/src/Devices/CO2Sensor.cpp
@@ -32,8 +32,7 @@ void CO2Sensor::configurePort()
         uart_port_.set_option(boost::asio::serial_port_base::stop_bits(
             boost::asio::serial_port_base::stop_bits::one));
     } catch (const std::exception &e) {
-        SPDLOG_ERROR("Error configuring serial port: {}", e.what());
-        throw;
+        throw std::runtime_error("Error configuring serial port: " + std::string(e.what()));
     }
 }
 

--- a/server/src/Devices/LED.cpp
+++ b/server/src/Devices/LED.cpp
@@ -1,4 +1,5 @@
 #include "LED.hpp"
+
 #include "SpdlogConfig.hpp"
 
 LED::LED(int pin) : pin_(pin)
@@ -7,15 +8,13 @@ LED::LED(int pin) : pin_(pin)
 
     chip_ = gpiod_chip_open_by_number(0);
     if (!chip_) {
-        SPDLOG_ERROR("Failed to open GPIO chip");
-        return;
+        throw std::runtime_error("Failed to open GPIO chip");
     }
 
     line_ = gpiod_chip_get_line(chip_, pin_);
     if (!line_) {
-        SPDLOG_ERROR("Failed to get GPIO line");
         gpiod_chip_close(chip_);
-        return;
+        throw std::runtime_error("Failed to get GPIO line");
     }
 
     setup_pin();
@@ -45,7 +44,6 @@ void LED::setup_pin()
     SPDLOG_TRACE("LED::setup_pin");
     int ret = gpiod_line_request_output(line_, "LED", 0);
     if (ret < 0) {
-        SPDLOG_ERROR("Failed to request line as output");
-        return;
+        throw std::runtime_error("Failed to request line as output");
     }
 }

--- a/server/src/Network/Session.cpp
+++ b/server/src/Network/Session.cpp
@@ -43,8 +43,13 @@ void Session::doRead()
                 auto json = nlohmann::json::parse(req->body());
                 SPDLOG_TRACE("Session::doRead | Got data from client: {}", json.dump());
 
-                RequestData requestData{.cmd    = json.at("cmd").get<std::string>(),
-                                        .param1 = json.at("param1").get<std::string>()};
+                RequestData requestData;
+                requestData.cmd = json.at("cmd").get<std::string>();
+                if (json.contains("params")) {
+                    requestData.params = json.at("params").get<std::vector<std::string>>();
+                } else {
+                    requestData.params = std::vector<std::string>{};
+                }
 
                 doTaskCallback_(requestData, [this, self](ResponseData data) {
                     SPDLOG_TRACE("SendResponseCallback");

--- a/server/src/Network/Session.hpp
+++ b/server/src/Network/Session.hpp
@@ -5,13 +5,15 @@
 #include <boost/beast.hpp>
 #include <functional>
 #include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
 #include <vector>
 
 #include "Data.hpp"
 
 class Session : public std::enable_shared_from_this<Session> {
 public:
-    Session(boost::asio::ip::tcp::socket &&socket, DoTaskCallback doTaskCallback,
+    Session(boost::asio::ip::tcp::socket socket, DoTaskCallback doTaskCallback,
             unsigned int sessionId);
 
     void start();
@@ -21,6 +23,8 @@ private:
     void doRead();
     void doWrite(const std::string &response);
     void doClose();
+    RequestData deserializeRequest(const std::string &requestBody);
+    std::string serializeResponse(const ResponseData &responseData);
 
 private:
     boost::asio::ip::tcp::socket socket_;


### PR DESCRIPTION
### General error handling refactoring
Server from now on will have solid error handling based on exceptions.
Also client is able to get server errors in response.

### Refactor params
From now on it's possible not to specify params key if it's not needed
```
curl -X POST http://192.168.31.142:12345 -H "Content-Type: application/json" -d '{"cmd":"warning_on"}'
curl -X POST http://192.168.31.142:12345 -H "Content-Type: application/json" -d '{"cmd":"warning_off"}'
```
```
╰─➤ sudo ./bin/MeasuringServer -s /dev/serial0 -i 600                                                                                                                                      
[1796] [2024-05-21 19:06:18.080] [trace] Server::handleAccept
[1796] [2024-05-21 19:06:18.080] [info] Connection accepted
[1796] [2024-05-21 19:06:18.080] [info] Session 2 created
[1796] [2024-05-21 19:06:18.080] [trace] Session::doRead
[1796] [2024-05-21 19:06:18.080] [trace] Server::startAccept
[1796] [2024-05-21 19:06:18.080] [trace] Session::doRead | Got data from client: {"cmd":"warning_on"}
[1796] [2024-05-21 19:06:18.081] [trace] DoTaskCallback
[1796] [2024-05-21 19:06:18.081] [trace] Application::doTask | cmd - warning_on
[1796] [2024-05-21 19:06:18.081] [info] LED is ON
[1796] [2024-05-21 19:06:18.081] [trace] SendResponseCallback
[1796] [2024-05-21 19:06:18.081] [trace] Session::doWrite | Sending to client: []
[1796] [2024-05-21 19:06:18.081] [info] Session 2: Data written successfully
[1796] [2024-05-21 19:06:18.081] [trace] Session::doClose
[1796] [2024-05-21 19:06:21.405] [trace] Server::handleAccept
[1796] [2024-05-21 19:06:21.405] [info] Connection accepted
[1796] [2024-05-21 19:06:21.405] [info] Session 3 created
[1796] [2024-05-21 19:06:21.405] [trace] Session::doRead
[1796] [2024-05-21 19:06:21.406] [trace] Server::startAccept
[1796] [2024-05-21 19:06:21.406] [trace] Session::doRead | Got data from client: {"cmd":"warning_off"}
[1796] [2024-05-21 19:06:21.406] [trace] DoTaskCallback
[1796] [2024-05-21 19:06:21.406] [trace] Application::doTask | cmd - warning_off
[1796] [2024-05-21 19:06:21.406] [info] LED is OFF
[1796] [2024-05-21 19:06:21.406] [trace] SendResponseCallback
[1796] [2024-05-21 19:06:21.406] [trace] Session::doWrite | Sending to client: []
[1796] [2024-05-21 19:06:21.407] [info] Session 3: Data written successfully
[1796] [2024-05-21 19:06:21.407] [trace] Session::doClose
```